### PR TITLE
Addresses variables sorting issues [GH#2]

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -17,5 +17,6 @@ WriteMakefile(
 		'aliased'           => 0,
 		'Set::Scalar'       => 0,
 		'Test::More'        => 0.98, # make sure we have subtest support
+		'Test::More::Hooks' => 0,
 	},
 );

--- a/lib/PPIx/EditorTools/ExtractMethod/CodeGenerator.pm
+++ b/lib/PPIx/EditorTools/ExtractMethod/CodeGenerator.pm
@@ -85,10 +85,9 @@ sub return_by_ref_vars {
 sub pass_list_external {
     my $self = shift;
     my @list = map {$_->id} $self->sorter->pass_bucket_sorted;
-    foreach my $var ( $self->sorter->pass_by_ref_bucket_sorted  ) {
+    foreach my $var ( $self->sorter->pass_by_ref_bucket_sorted ) {
         push @list, $var->make_reference;
     }
-    @list = sort @list;
     return @list;
 }
 
@@ -98,7 +97,6 @@ sub pass_list_internal {
     foreach my $var ( $self->sorter->pass_by_ref_bucket_sorted ) {
         push @list, '$' . $var->name;
     }
-    @list = sort @list;
     return @list;
 }
 
@@ -108,7 +106,6 @@ sub dereference_list_external {
     foreach my $var ( $self->sorter->return_by_ref_bucket_sorted  ) {
         push @list, [$var->id,  $var->type . '$' . $var->name];
     }
-    @list = sort {$a->[0] cmp $b->[0]} @list;
     return @list;
 }
 
@@ -118,7 +115,6 @@ sub dereference_list_internal {
     foreach my $var ( $self->sorter->pass_by_ref_bucket_sorted ) {
         push @list, [$var->id,  $var->type . '$' . $var->name];
     }
-    @list = sort {$a->[0] cmp $b->[0]} @list;
     return @list;
 }
 
@@ -128,7 +124,6 @@ sub return_list_internal {
     foreach my $var ( $self->sorter->return_by_ref_bucket_sorted ) {
         push @list, $var->make_reference;
     }
-    @list = sort @list;
     return @list;
 }
 
@@ -138,7 +133,6 @@ sub return_list_external {
     foreach my $var ( $self->sorter->return_by_ref_bucket_sorted ) {
         push @list, '$' . $var->name;
     }
-    @list = sort @list;
     return @list;
 }
 

--- a/lib/PPIx/EditorTools/ExtractMethod/VariableSorter.pm
+++ b/lib/PPIx/EditorTools/ExtractMethod/VariableSorter.pm
@@ -23,10 +23,14 @@ has 'return_bucket' => (
     default => sub { [] },
     handles => {
         add_to_return_bucket  => 'push',
-        return_bucket_sorted => 'sort',
+        _return_bucket_sorted => 'sort',
         return_bucket_count => 'count',
     },
 );
+
+sub return_bucket_sorted {
+    return shift->_return_bucket_sorted( sub { _cmp_variables(@_) } );
+}
 
 has 'pass_bucket' => (
     traits  => ['Array'],
@@ -35,10 +39,14 @@ has 'pass_bucket' => (
     default => sub { [] },
     handles => {
         add_to_pass_bucket  => 'push',
-        pass_bucket_sorted => 'sort',
+        _pass_bucket_sorted => 'sort',
         pass_bucket_count => 'count',
     },
 );
+sub pass_bucket_sorted {
+    return shift->_pass_bucket_sorted( sub {_cmp_variables(@_)} );
+}
+
 =head2 return_and_declare_bucket
 
 Variables that are declared inside the extracted region and used later need to
@@ -53,10 +61,14 @@ has 'return_and_declare_bucket' => (
     default => sub { [] },
     handles => {
         add_to_return_and_declare_bucket  => 'push',
-        return_and_declare_bucket_sorted => 'sort',
+        _return_and_declare_bucket_sorted => 'sort',
         return_and_declare_bucket_count => 'count',
     },
 );
+sub return_and_declare_bucket_sorted {
+    return shift->_return_and_declare_bucket_sorted( sub { _cmp_variables(@_) } );
+}
+
 
 =head2 return_by_ref_bucket
 
@@ -71,10 +83,14 @@ has 'return_by_ref_bucket' => (
     default => sub { [] },
     handles => {
         add_to_return_by_ref_bucket  => 'push',
-        return_by_ref_bucket_sorted => 'sort',
+        _return_by_ref_bucket_sorted => 'sort',
         return_by_ref_bucket_count => 'count',
     },
 );
+sub return_by_ref_bucket_sorted {
+    return shift->_return_by_ref_bucket_sorted( sub { _cmp_variables(@_) } );
+}
+
 
 =head2 pass_by_ref_bucket
 
@@ -89,10 +105,19 @@ has 'pass_by_ref_bucket' => (
     default => sub { [] },
     handles => {
         add_to_pass_by_ref_bucket  => 'push',
-        pass_by_ref_bucket_sorted => 'sort',
+        _pass_by_ref_bucket_sorted => 'sort',
         pass_by_ref_bucket_count => 'count',
     },
 );
+sub pass_by_ref_bucket_sorted {
+    return shift->_pass_by_ref_bucket_sorted( sub { _cmp_variables(@_) } );
+}
+
+sub _cmp_variables {
+    my ($a,$b) = @_;
+    return unless defined $a && defined $b;
+    return $a->type . $a->name cmp $b->type . $b->name;
+}
 
 sub to_pass {
     my ($self, $var) = @_;
@@ -117,7 +142,7 @@ sub to_return {
 sub process_input {
     my $self = shift;
     $self->return_statement_at_end($self->analyzer_result->return_statement_at_end);
-    foreach my $var (values %{$self->analyzer_result->variables}) {
+    foreach my $var (sort values %{$self->analyzer_result->variables}) {
         next if ($var->name eq 'self');
         next if ($var->is_special_variable);
         if (!$var->declared_in_selection && !$var->used_after)

--- a/t/code_generator.t
+++ b/t/code_generator.t
@@ -92,12 +92,12 @@ subtest 'can generate list of variables to return' => sub  {
 };
 
 subtest 'can generate list of returned variables' => sub  {
-    is(join(',', $generator->return_list_external), '$bar,$inside_array,$to_return');
+    is(join(',', $generator->return_list_external), '$bar,$to_return,$inside_array');
 };
 
 subtest 'can generate argument list' => sub  {
     (my $arg_list = $generator->arg_list) =~ s/(\$qux),(\s*)(\$baz)/$3,$2$1/;
-    is($arg_list, 'my ($self, $baz, $inside_array, $qux) = @_;');
+    is($arg_list, 'my ($self, $baz, $qux, $inside_array) = @_;');
 };
 
 subtest 'can generate argument dereferencing' => sub  {
@@ -132,7 +132,7 @@ subtest 'can generate declarations of returned variables and references' => sub 
 
 
 subtest 'can generate list of returned vars' => sub  {
-    is($generator->returned_vars, '($bar, $inside_array, $to_return)');
+    is($generator->returned_vars, '($bar, $to_return, $inside_array)');
 };
 
 subtest 'can generate simplifed list of returned vars if only one var' => sub  {
@@ -150,7 +150,7 @@ subtest 'can generate call to method' => sub  {
     is(
         $generator->method_call('new_method'),
         'my ($bar, $inside_array, $to_return, %to_return);' . "\n" .
-        '($bar, $inside_array, $to_return) = $self->new_method($baz, $qux, \@inside_array);' . "\n" .
+        '($bar, $to_return, $inside_array) = $self->new_method($baz, $qux, \@inside_array);' . "\n" .
         '%to_return = %$to_return;' . "\n" .
         '@inside_array = @$inside_array;'
     );
@@ -158,7 +158,7 @@ subtest 'can generate call to method' => sub  {
 
 subtest 'can generate method body' => sub  {
     my $expected = q!sub new_method {
-        my ($self, $baz, $inside_array, $qux) = @_;
+        my ($self, $baz, $qux, $inside_array) = @_;
         my @inside_array = @$inside_array;
         my %to_return = 42; $inside_array[0] = 43;
         my $foo; my $bar = $baz + $qux;

--- a/t/data/output/RenameVariable.pm
+++ b/t/data/output/RenameVariable.pm
@@ -119,7 +119,7 @@ sub rename {
 
 	#warn "VARNAME: $varname";
 
-my ($patterns, @patterns, $type);
+my ($patterns, $type, @patterns);
 ($type, $patterns) = $self->symbol_patterns($varname);
 @patterns = @$patterns;
 	my %unique;


### PR DESCRIPTION
Since the same variable may have a different sigil in different
contexts, we need to do the sorting where we know the type of the _source_
variable. For example:

  my ($scalar, $hashref) = new_sub (){
    return ($scalar, \%hashref);
  }

This patch moves the sorting into VariableSorter.
